### PR TITLE
used `subutai exists {container}` instead of `subutai list c` to fix …

### DIFF
--- a/management/server/core/host-registry/host-registry-impl/src/main/java/io/subutai/core/hostregistry/impl/HostNotifier.java
+++ b/management/server/core/host-registry/host-registry-impl/src/main/java/io/subutai/core/hostregistry/impl/HostNotifier.java
@@ -184,14 +184,7 @@ public class HostNotifier implements Runnable
 
                     try
                     {
-                        for ( String name : resourceHost.listExistingContainerNames() )
-                        {
-                            if ( oldContainerInfo.getContainerName().equalsIgnoreCase( name ) )
-                            {
-                                containerStillExists = true;
-                                break;
-                            }
-                        }
+                        containerStillExists = resourceHost.lxcExists( oldContainerInfo.getContainerName() );
                     }
                     catch ( ResourceHostException e )
                     {

--- a/management/server/core/local-peer/local-peer-impl/src/main/java/io/subutai/core/localpeer/impl/ResourceHostCommands.java
+++ b/management/server/core/local-peer/local-peer-impl/src/main/java/io/subutai/core/localpeer/impl/ResourceHostCommands.java
@@ -196,4 +196,10 @@ public class ResourceHostCommands
     {
         return new RequestBuilder( "date +\"%z\"" );
     }
+
+
+    public RequestBuilder getCheckLxcExistsCommand( String name )
+    {
+        return new RequestBuilder( String.format( "subutai exists %s", name ) );
+    }
 }

--- a/management/server/core/local-peer/local-peer-impl/src/main/java/io/subutai/core/localpeer/impl/entity/ResourceHostEntity.java
+++ b/management/server/core/local-peer/local-peer-impl/src/main/java/io/subutai/core/localpeer/impl/entity/ResourceHostEntity.java
@@ -1779,6 +1779,22 @@ public class ResourceHostEntity extends AbstractSubutaiHost implements ResourceH
 
 
     @Override
+    public Boolean lxcExists( final String name ) throws ResourceHostException
+    {
+        try
+        {
+            CommandResult result = execute( resourceHostCommands.getCheckLxcExistsCommand( name ) );
+            return result.hasSucceeded();
+        }
+        catch ( CommandException e )
+        {
+            throw new ResourceHostException(
+                    String.format( "Error checking lxc instance existence: %s", e.getMessage() ), e );
+        }
+    }
+
+
+    @Override
     public Set<ContainerInfo> listExistingContainersInfo() throws ResourceHostException
     {
 

--- a/management/server/subutai-common/src/main/java/io/subutai/common/peer/ResourceHost.java
+++ b/management/server/subutai-common/src/main/java/io/subutai/common/peer/ResourceHost.java
@@ -220,6 +220,13 @@ public interface ResourceHost extends Host, ResourceHostInfo
 
     Set<ContainerInfo> listExistingContainersInfo() throws ResourceHostException;
 
+    /**
+     * Checks if lxc instance exists
+     *
+     * @param name name of container or template
+     */
+    Boolean lxcExists( String name ) throws ResourceHostException;
+
 
     ReservedPorts getReservedPorts() throws ResourceHostException;
 


### PR DESCRIPTION
…problem with disappearing containers during rollback of snapshots